### PR TITLE
downgrade vs min version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "breakpoints-manager",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "breakpoints-manager",
-      "version": "0.0.1",
+      "version": "0.1.0",
+      "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.7",
         "@types/node": "20.x",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "pricing": "Free",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.93.0"
+    "vscode": "^1.92.0"
   },
   "repository": {
     "url": "https://github.com/loukas-kotas/breakpoints-manager"
@@ -150,7 +150,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.7",
     "@types/node": "20.x",
-    "@types/vscode": "^1.93.0",
+    "@types/vscode": "^1.92.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
     "@vscode/test-cli": "^0.0.10",


### PR DESCRIPTION
> Saw it in the package.json, is it mandatory? https://github.com/loukas-kotas/breakpoints-manager/issues/1

I could compile + install with no issues after downgrading that minimal version, so it seems not mandatory.

Btw the package lock changes were not pushed last time? They were updated when I compiled the extension
